### PR TITLE
Add attach support to nvim-java

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -674,6 +674,7 @@ require('lazy').setup({
       })
       require('mason-tool-installer').setup { ensure_installed = ensure_installed }
 
+      ---@diagnostic disable-next-line: missing-fields
       require('mason-lspconfig').setup {
         handlers = {
           function(server_name)
@@ -685,6 +686,41 @@ require('lazy').setup({
             require('lspconfig')[server_name].setup(server)
           end,
           jdtls = function()
+            vim.api.nvim_create_autocmd('LspAttach', {
+              group = vim.api.nvim_create_augroup('extend-nvim-java-dap-config', {}),
+              callback = function(args)
+                local client = vim.lsp.get_client_by_id(args.data.client_id)
+
+                if client == nil then
+                  return
+                end
+
+                local server_name = client.name
+
+                if server_name ~= 'jdtls' then
+                  return
+                end
+
+                -- to try and run after `nvim-java` autocmd
+                vim.schedule(function()
+                  local dap = require 'dap'
+                  assert(
+                    dap.configurations.java ~= nil,
+                    "If you see this, nvim-java hasn't set it's dap config. Maybe we need to use `vim.defer_fn` instead of `vim.schedule`"
+                  )
+                  table.insert(dap.configurations.java, {
+                    type = 'java',
+                    request = 'attach',
+                    name = 'Debug (Attach) - Remote',
+                    hostName = '127.0.0.1',
+                    port = 5005,
+                  })
+                end)
+              end,
+              -- depending on your workflow, you may need to remove this.
+              -- If you work on multiple projects in a single Neovim instance, for example
+              once = true,
+            })
             require('java').setup {
               -- Your custom jdtls settings goes here
             }


### PR DESCRIPTION
(warning: `nvim-java` code seems really convoluted and spans several different repos for some reason)

On `setup`

https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java.lua#L43

nvim-java creates an autocmd

https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/api/dap.lua#L13

for creating the dap config on the `LspAttach` event

https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/api/dap.lua#L39
https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/api/dap.lua#L52
https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/api/dap.lua#L30
https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/dap/init.lua#L23
https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/dap/init.lua#L33

which eventually sets `dap.configurations.java` to it's own config.

https://github.com/nvim-java/nvim-java/blob/e8e84413ca03e7d0541921e795b2e6bf8801f186/lua/java/dap/init.lua#L108

This config adds the entries for launching test that you mentioned [in your comment](https://www.reddit.com/r/neovim/comments/1hvjlrn/comment/m61x992/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button).

So, if you set `dap.configurations.java` to any value before this, `nvim-java` will simply override it (which is a terrible choice, in my opinnion, specially because the configurations are defined dynamically, so it leads to problems like the one you are facing where your custom configuration simply gets overridden. I would suggest oppening an issue on the `nvim-java` repo asking for a way to extend of extending the dap config or at least for them to use `table.insert` to add their configs to the existing java configs instead of overwriting them).

Since `nvim-java` doesn't seem to have a way to add a custom config

https://github.com/nvim-java/nvim-java-dap/blob/55f239532f7a3789d21ea68d1e795abc77484974/lua/java-dap/api/setup.lua#L79-L90

 we are gonna have to work around it by also using an autocmd on `LspAttach` and `vim.schedule` (so the callback should run after the `nvim-java` callback)

(I'm writting this in real-time. I see that you [have already opened an issue on `nvim-java`](https://github.com/nvim-java/nvim-java/issues/340), my guess is that the developer isn't conscious of the problem of how their plugin is currently working. If you explain it to them, they may help you and this workaround may no longer be needed)

Take into account that I haven't tried your config personally. With this changes, do the same thing I asked on reddit in order to print the dap configurations available to see if `nvim-java` keeps overriding them